### PR TITLE
Replace dependencies where possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@material-ui/core": "^4.12.1",
     "@material-ui/icons": "^4.11.2",
     "htmlparser2": "^6.1.0",
-    "md5": "^2.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@material-ui/core": "^4.12.1",
     "@material-ui/icons": "^4.11.2",
-    "axios": "^0.21.1",
     "htmlparser2": "^6.1.0",
     "md5": "^2.3.0",
     "react": "^17.0.2",

--- a/src/utils/fetchFeeds.ts
+++ b/src/utils/fetchFeeds.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { parseFeed } from 'htmlparser2'
 
 import type { Feed } from '../types'
@@ -65,12 +64,13 @@ export default async function fetchFeeds(
             if (!forceRefetch && lastPull > getRefetchThreshold())
                 return storedFeedData
 
-            const response = await axios.get('/.netlify/functions/rss-proxy', {
-                params: { url },
-            })
+            const response = await fetch(
+                `/.netlify/functions/rss-proxy?url=${url}`,
+            )
+            const responseData = await response.text()
 
             try {
-                const newFeedData = parseFeed(response.data)
+                const newFeedData = parseFeed(responseData)
                 const newFeed = processFeedXML(newFeedData)
                 const mergedFeeds = storedFeedData
                     ? mergeFeeds(storedFeedData, newFeed)

--- a/src/utils/fetchFeeds.ts
+++ b/src/utils/fetchFeeds.ts
@@ -67,6 +67,9 @@ export default async function fetchFeeds(
             const response = await fetch(
                 `/.netlify/functions/rss-proxy?url=${url}`,
             )
+
+            if (!response.ok) return storedFeedData
+
             const responseData = await response.text()
 
             try {
@@ -87,5 +90,5 @@ export default async function fetchFeeds(
         }),
     )
 
-    return feeds
+    return feeds.filter((feed) => feed)
 }

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -1,9 +1,11 @@
-import md5 from 'md5'
-
 import type { RSSData, Settings } from '../types'
 
 const SETTINGS_KEY = 'settings'
 const RSS_DATA_KEY_PREFIX = 'savedItems_'
+
+function cacheKeyFromURL(url: string): string {
+    return url.replace(/^https?:\/\//, '').replace(/\/$/, '')
+}
 
 function storeToLocal(key: string, data): void {
     window.localStorage.setItem(key, JSON.stringify(data))
@@ -26,11 +28,11 @@ export function restoreSettings(): Settings {
 }
 
 export function storeRssData(url: string, items: Item[]): void {
-    const key = RSS_DATA_KEY_PREFIX + md5(url)
+    const key = RSS_DATA_KEY_PREFIX + cacheKeyFromURL(url)
     storeToLocal(key, items)
 }
 
 export function restoreRssData(url: string): RSSData {
-    const key = RSS_DATA_KEY_PREFIX + md5(url)
+    const key = RSS_DATA_KEY_PREFIX + cacheKeyFromURL(url)
     return restoreFromLocal(key)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5617,13 +5617,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"charenc@npm:0.0.2":
-  version: 0.0.2
-  resolution: "charenc@npm:0.0.2"
-  checksum: 81dcadbe57e861d527faf6dd3855dc857395a1c4d6781f4847288ab23cffb7b3ee80d57c15bba7252ffe3e5e8019db767757ee7975663ad2ca0939bb8fcaf2e5
-  languageName: node
-  linkType: hard
-
 "chokidar@npm:^3.0.2":
   version: 3.5.2
   resolution: "chokidar@npm:3.5.2"
@@ -6417,13 +6410,6 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
-  languageName: node
-  linkType: hard
-
-"crypt@npm:0.0.2":
-  version: 0.0.2
-  resolution: "crypt@npm:0.0.2"
-  checksum: baf4c7bbe05df656ec230018af8cf7dbe8c14b36b98726939cef008d473f6fe7a4fad906cfea4062c93af516f1550a3f43ceb4d6615329612c6511378ed9fe34
   languageName: node
   linkType: hard
 
@@ -10058,7 +10044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-buffer@npm:^1.1.5, is-buffer@npm:~1.1.6":
+"is-buffer@npm:^1.1.5":
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 4a186d995d8bbf9153b4bd9ff9fd04ae75068fe695d29025d25e592d9488911eeece84eefbd8fa41b8ddcc0711058a71d4c466dcf6f1f6e1d83830052d8ca707
@@ -12305,17 +12291,6 @@ __metadata:
     inherits: ^2.0.1
     safe-buffer: ^5.1.2
   checksum: 098494d885684bcc4f92294b18ba61b7bd353c23147fbc4688c75b45cb8590f5a95fd4584d742415dcc52487f7a1ef6ea611cfa1543b0dc4492fe026357f3f0c
-  languageName: node
-  linkType: hard
-
-"md5@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "md5@npm:2.3.0"
-  dependencies:
-    charenc: 0.0.2
-    crypt: 0.0.2
-    is-buffer: ~1.1.6
-  checksum: a63cacf4018dc9dee08c36e6f924a64ced735b37826116c905717c41cebeb41a522f7a526ba6ad578f9c80f02cb365033ccd67fe186ffbcc1a1faeb75daa9b6e
   languageName: node
   linkType: hard
 
@@ -15779,7 +15754,6 @@ __metadata:
     eslint-plugin-react-hooks: ^4.2.0
     htmlparser2: ^6.1.0
     jest: ^27.0.6
-    md5: ^2.3.0
     netlify-cli: ^5.2.3
     parcel: ^2.0.0-beta.2
     prettier: ^2.3.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4793,15 +4793,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1":
-  version: 0.21.1
-  resolution: "axios@npm:0.21.1"
-  dependencies:
-    follow-redirects: ^1.10.0
-  checksum: c87915fa0b18c15c63350112b6b3563a3e2ae524d7707de0a73d2e065e0d30c5d3da8563037bc29d4cc1b7424b5a350cb7274fa52525c6c04a615fe561c6ab11
-  languageName: node
-  linkType: hard
-
 "axobject-query@npm:^2.2.0":
   version: 2.2.0
   resolution: "axobject-query@npm:2.2.0"
@@ -8668,7 +8659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.10.0":
+"follow-redirects@npm:^1.0.0":
   version: 1.14.1
   resolution: "follow-redirects@npm:1.14.1"
   peerDependenciesMeta:
@@ -15776,7 +15767,6 @@ __metadata:
     "@tophat/eslint-import-resolver-require": ^0.1.3
     "@typescript-eslint/eslint-plugin": ^4.28.3
     "@typescript-eslint/parser": ^4.28.3
-    axios: ^0.21.1
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
     eslint-import-resolver-node: ^0.3.4


### PR DESCRIPTION
`axios` and `md5` were underused and not really pulling their weight when considering the weight they add to the bundle.

- Replaces `axios` with `fetch`. [Browser compat](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility) should not be a problem for what is being used here.
- Replaces `md5` with some text subs. It's only used for keying local storage, hashing doesn't bring more value than just using the URL itself as a key (as opposed to `md5(url)`).

## Consequence

The local storage keying is changing, which will invalidate existing caches.