### PR TITLE
fix: chunked responses

### DIFF
--- a/netlify/functions/rss-proxy/rss-proxy.js
+++ b/netlify/functions/rss-proxy/rss-proxy.js
@@ -3,7 +3,9 @@ const https = require('https')
 async function httpGet(url) {
     return new Promise((resolve) => {
         https.get(url, (response) => {
-            response.on('data', (d) => resolve(d))
+            const chunks = []
+            response.on('data', (d) => chunks.push(d))
+            response.on('end', () => resolve(chunks.join('')))
         })
     })
 }

--- a/src/utils/fetchFeeds.ts
+++ b/src/utils/fetchFeeds.ts
@@ -28,15 +28,18 @@ function getRefetchThreshold() {
 
 function mergeFeeds(first, second) {
     // Assuming `second` is newer.
-    const seen = new Set(items.map((item) => item.url))
-    const mergedItems = newFeedItems.reduce((updatedItems, item) => {
-        if (!seen.has(item.url)) {
-            updatedItems.push(item)
-            seen.add(item.url)
-        }
+    const seen = new Set(first.items.map((item) => item.url))
+    const mergedItems = second.items.reduce(
+        (updatedItems, item) => {
+            if (!seen.has(item.url)) {
+                updatedItems.push(item)
+                seen.add(item.url)
+            }
 
-        return updatedItems
-    }, [])
+            return updatedItems
+        },
+        [...first.items],
+    )
     return {
         ...second,
         items: mergedItems,
@@ -83,7 +86,7 @@ export default async function fetchFeeds(
                 return mergedFeeds
             } catch (e) {
                 // eslint-disable-next-line no-console
-                console.error(e.response)
+                console.error(e)
             }
 
             return storedFeedData


### PR DESCRIPTION
Chunked responses were previously not supported by the proxy, which resulted in only the first chunk being read.

This also fixes some feed merging logic that was broken but flew under the radar sue to not being often used.