### PR TITLE
build: resolve minimist@1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "preact": "^10.5.14",
     "react-query": "^3.34.16"
   },
+  "resolutions": {
+    "minimist": "^1.2.6"
+  },
   "alias": {
     "react": "preact/compat",
     "react-dom": "preact/compat"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12833,10 +12833,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+"minimist@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "minimist@npm:1.2.6"
+  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Forces the resolution of `minimist` to `^1.2.6` to patch the gap flagged by a [security advisory](https://github.com/advisories/GHSA-xvch-5gv4-984h) for `minimist<=1.2.5`.

Better fix includes updates to the packages that rely on `minimist`, but that might lag behind a bit.