### PR TITLE
fix: handle invalid feeds

### DIFF
--- a/src/FeedsPanel.tsx
+++ b/src/FeedsPanel.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles'
 
 import useSettings from './hooks/useSettings'
 import useRSSFeeds from './hooks/useRSSFeeds'
-import sortFeedItemsByDate from './utils/sortFeedItemsByDate'
+import sortFeedItemsByDate from './utils'
 
 interface CardProps {
     title: string

--- a/src/hooks/useRSSFeeds.ts
+++ b/src/hooks/useRSSFeeds.ts
@@ -2,6 +2,7 @@ import { parseFeed } from 'htmlparser2'
 import { useQueries } from 'react-query'
 
 import { Feed } from '../types'
+import { isDev } from '../utils'
 
 import useLocalStorage from './useLocalStorage'
 
@@ -58,8 +59,10 @@ async function fetchFeed(
 
         return mergedFeeds
     } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e)
+        if (isDev()) {
+            // eslint-disable-next-line no-console
+            console.error(e)
+        }
     }
 
     return persistedData
@@ -88,7 +91,7 @@ export default function useRSSFeeds(urls: string[]): { feeds: Feed[] } {
     )
 
     const fetchedFeeds = queries.reduce((fetchedFeeds: Feed[], current) => {
-        if (current.isSuccess) fetchedFeeds.push(current.data)
+        if (current.isSuccess && current.data) fetchedFeeds.push(current.data)
 
         return fetchedFeeds
     }, [])

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Feed, Item } from '../types'
+import type { Feed, Item } from './types'
 
 export default function sortFeedItemsByDate(feeds: Feed[]): Item[] {
     const flattened = feeds.reduce((flattenedFeeds, feed) => {
@@ -13,4 +13,8 @@ export default function sortFeedItemsByDate(feeds: Feed[]): Item[] {
     return flattened.sort((first, second) =>
         first.published > second.published ? -1 : 1,
     )
+}
+
+export function isDev(): boolean {
+    return process.env.NODE_ENV === 'development'
 }


### PR DESCRIPTION
# Description

Invalid feeds can be entered in the _Settings_ page, but would currently cause the app to crash since the feed parse would not handle non-feed data properly. This fixes that.

Additionally, removing some cruft around how utility functions are organized.

# AuthorQA

- :heavy_check_mark: Sanity start
- :heavy_check_mark: Checked that an invalid feed address doesn't lead to a crashed app
- :heavy_check_mark: Checked that a valid feed address leads to feed items populating the _Feeds_ page